### PR TITLE
7 vendor mount was overwriting composer install

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 APP_NAME=app_name
 APP_URL=http://localhost
+NODE_ENV=dev
 
 DB_CONNECTION=pgsql
 DB_HOST=database

--- a/backend/docker-compose.yaml
+++ b/backend/docker-compose.yaml
@@ -26,5 +26,6 @@ services:
       - "8000:8000"
     volumes:
       - .:/var/www/backend
+      - /var/www/backend/vendor
     depends_on:
       - database

--- a/backend/docker/php/Dockerfile
+++ b/backend/docker/php/Dockerfile
@@ -36,7 +36,7 @@ COPY . ${working_dir}
 COPY docker/php/supervisor/supervisord.conf /etc/supervisord.conf
 
 # Install PHP dependencies
-RUN composer install --no-dev --optimize-autoloader && \
+RUN composer install --optimize-autoloader && \
     php artisan key:generate && \
     php artisan config:clear && \
     php artisan config:cache


### PR DESCRIPTION
What is happening here: .:/var/www/backend mounts everything in the host directory `.` to this directory in the container`/var/www/backend`. This is the same behavior as a shared directory with a VM. The problem is that a volume mount is performed after the container is built in the Dockerfile and since we have an empty vendor file on the host machine, it overwrites the vendor file in the container, effectively partially uninstalling composer. 

We are also in dev so flags modified to support this. Certain packages are necessary and included for a dev vs production environment.